### PR TITLE
Fixes update abstract typing relation and abstract update value relation

### DIFF
--- a/c-refinement/Cogent_Corres.thy
+++ b/c-refinement/Cogent_Corres.thy
@@ -20,7 +20,7 @@ theory Cogent_Corres
 begin
 
 locale update_sem_init = update_sem +
-constrains abs_typing :: "abstyp \<Rightarrow> name \<Rightarrow> type list \<Rightarrow> sigil \<Rightarrow> ptrtyp set \<Rightarrow> ptrtyp set \<Rightarrow> bool"
+constrains abs_typing :: "abstyp \<Rightarrow> name \<Rightarrow> type list \<Rightarrow> sigil \<Rightarrow> ptrtyp set \<Rightarrow> ptrtyp set \<Rightarrow> (funtyp, abstyp, ptrtyp) store \<Rightarrow> bool"
        and abs_repr :: "abstyp \<Rightarrow> name \<times> repr list"
 
 context update_sem_init

--- a/c-refinement/Cogent_Corres_Shallow_C.thy
+++ b/c-refinement/Cogent_Corres_Shallow_C.thy
@@ -29,9 +29,9 @@ begin
 
 locale correspondence_init =
   correspondence +
-  constrains upd_abs_typing :: "abstyp \<Rightarrow> name \<Rightarrow> type list \<Rightarrow> sigil \<Rightarrow> ptrtyp set \<Rightarrow> ptrtyp set \<Rightarrow> bool"
+  constrains upd_abs_typing :: "abstyp \<Rightarrow> name \<Rightarrow> type list \<Rightarrow> sigil \<Rightarrow> ptrtyp set \<Rightarrow> ptrtyp set \<Rightarrow> (funtyp, abstyp, ptrtyp) store \<Rightarrow> bool"
        and abs_repr :: "abstyp \<Rightarrow> name \<times> repr list"
-       and abs_upd_val :: "abstyp \<Rightarrow> 'b \<Rightarrow> char list \<Rightarrow> Cogent.type list \<Rightarrow> sigil \<Rightarrow> ptrtyp set \<Rightarrow> ptrtyp set \<Rightarrow> bool"
+       and abs_upd_val :: "abstyp \<Rightarrow> 'b \<Rightarrow> char list \<Rightarrow> Cogent.type list \<Rightarrow> sigil \<Rightarrow> ptrtyp set \<Rightarrow> ptrtyp set \<Rightarrow> (funtyp, abstyp, ptrtyp) store \<Rightarrow> bool"
 
 sublocale correspondence_init \<subseteq> update_sem_init upd_abs_typing abs_repr
   by (unfold_locales)

--- a/cogent/isa/Correspondence.thy
+++ b/cogent/isa/Correspondence.thy
@@ -285,7 +285,7 @@ definition proc_env_u_v_matches :: "(('f, 'au, 'l) uabsfuns)
                       \<longrightarrow> \<xi> f (\<sigma>, a) (\<sigma>', v)
                       \<longrightarrow> (\<xi>' f a' v'
                            \<longrightarrow> (\<exists>r' w'. (\<Xi> , \<sigma>' \<turnstile> v \<sim> v' : instantiate \<tau>s \<tau>o \<langle>r', w'\<rangle>)
-                                    \<and> r' \<subseteq> r \<and> upd.frame \<sigma> w \<sigma>' w'))
+                                    \<and> r' \<subseteq> r \<and> frame \<sigma> w \<sigma>' w'))
                        \<and> (\<exists> v'. \<xi>' f a' v')))"
 
 lemma upd_val_rel_record:
@@ -938,7 +938,7 @@ and     "\<xi> f (\<sigma>, a) (\<sigma>', v)"
 and     "\<xi>' f a' v'"
 shows   "\<exists>r' w'.
              \<Xi> , \<sigma>' \<turnstile> v \<sim> v' : instantiate \<tau>s \<tau>o \<langle>r', w'\<rangle>
-            \<and> r' \<subseteq> r \<and> upd.frame \<sigma> w \<sigma>' w'"
+            \<and> r' \<subseteq> r \<and> frame \<sigma> w \<sigma>' w'"
   using assms by (clarsimp simp: proc_env_u_v_matches_def, drule_tac x = f in spec, fastforce)
 
 section {* frame *}
@@ -990,7 +990,7 @@ shows   "\<sigma> p \<noteq> None"
 using assms by (auto dest: u_v_matches_to_matches_ptrs upd.matches_ptrs_valid)
 
 lemma upd_val_rel_frame:
-assumes "upd.frame \<sigma> w1 \<sigma>' w2"
+assumes "frame \<sigma> w1 \<sigma>' w2"
 and     "w \<inter> w1 = {}"
 and     "r \<inter> w1 = {}"
 shows   "\<Xi> , \<sigma> \<turnstile>  u  \<sim> v  :  t  \<langle> r , w \<rangle> \<Longrightarrow> \<Xi> , \<sigma>' \<turnstile>  u  \<sim> v  : t   \<langle> r , w \<rangle>"
@@ -1005,22 +1005,22 @@ next case u_v_function then show ?case by (simp add: upd_val_rel_upd_val_rel_rec
 next case u_v_afun     then show ?case by (simp add: upd_val_rel_upd_val_rel_record.u_v_afun)
 next case u_v_unit     then show ?case by (simp add: upd_val_rel_upd_val_rel_record.u_v_unit)
 next case u_v_p_rec_ro then show ?case by (auto intro!: upd_val_rel_upd_val_rel_record.u_v_p_rec_ro
-                                                simp:   upd.frame_def)
+                                                simp:   frame_def)
 next case u_v_p_rec_w  then show ?case by (auto intro!: upd_val_rel_upd_val_rel_record.u_v_p_rec_w
-                                                simp:   upd.frame_def)
+                                                simp:   frame_def)
 next case u_v_p_abs_ro then show ?case by (auto intro!: upd_val_rel_upd_val_rel_record.u_v_p_abs_ro
-                                                simp:   upd.frame_def)
+                                                simp:   frame_def)
 next case u_v_p_abs_w  then show ?case by (auto intro!: upd_val_rel_upd_val_rel_record.u_v_p_abs_w
-                                                simp:   upd.frame_def)
+                                                simp:   frame_def)
 next case u_v_r_empty  then show ?case by (simp add: upd_val_rel_upd_val_rel_record.u_v_r_empty)
 next case u_v_r_cons1  then show ?case by (force intro!: upd_val_rel_upd_val_rel_record.u_v_r_cons1
-                                                 simp: upd.frame_def)
+                                                 simp: frame_def)
 next case u_v_r_cons2  then show ?case by (simp add: upd_val_rel_upd_val_rel_record.u_v_r_cons2)
 qed
 
 lemma u_v_matches_frame:
 assumes "\<Xi> , \<sigma> \<turnstile> u \<sim> v matches t \<langle> r , w \<rangle>"
-and     "upd.frame \<sigma> w1 \<sigma>' w2"
+and     "frame \<sigma> w1 \<sigma>' w2"
 and     "w1 \<inter> w = {}"
 and     "w1 \<inter> r = {}"
 shows   "\<Xi> , \<sigma>' \<turnstile> u \<sim> v matches t \<langle> r , w \<rangle>"
@@ -1032,21 +1032,21 @@ next case u_v_matches_some  then show ?case by (fast dest:   upd_val_rel_frame(1
 qed
 
 lemma frame_noalias_upd_val_rel :
-assumes "upd.frame \<sigma> u \<sigma>' u'"
+assumes "frame \<sigma> u \<sigma>' u'"
 and     "\<Xi>, \<sigma> \<turnstile> v \<sim> v' : \<tau> \<langle>r, w\<rangle>"
 shows   "u  \<inter> w = {} \<Longrightarrow> u' \<inter> w = {}"
 and     "u  \<inter> r = {} \<Longrightarrow> u' \<inter> r = {}"
   using assms by (auto dest: upd_val_rel_to_uval_typing upd.frame_noalias_uval_typing)
 
 lemma frame_noalias_u_v_matches :
-assumes "upd.frame \<sigma> u \<sigma>' u'"
+assumes "frame \<sigma> u \<sigma>' u'"
 and     "\<Xi>, \<sigma> \<turnstile> \<gamma> \<sim> \<gamma>' matches \<Gamma> \<langle>r, w\<rangle>"
 shows   "u  \<inter> w = {} \<Longrightarrow> u' \<inter> w = {}"
 and     "u  \<inter> r = {} \<Longrightarrow> u' \<inter> r = {}"
   using assms by (auto dest: u_v_matches_to_matches_ptrs upd.frame_noalias_matches_ptrs)
 
 lemma frame_noalias_upd_val_rel' :
-assumes "upd.frame \<sigma> u \<sigma>' u'"
+assumes "frame \<sigma> u \<sigma>' u'"
 and     "\<Xi>, \<sigma> \<turnstile> v \<sim> v' : \<tau> \<langle>r, w\<rangle>"
 shows   "w \<inter> u = {} \<Longrightarrow> w \<inter> u' = {}"
 and     "r \<inter> u = {} \<Longrightarrow> r \<inter> u' = {}"
@@ -1054,8 +1054,8 @@ using assms by (auto dest: upd_val_rel_to_uval_typing upd.frame_noalias_uval_typ
 
 
 lemma frame_noalias_2_uv :
-assumes "upd.frame \<sigma>  u \<sigma>'  u'"
-and     "upd.frame \<sigma>' w \<sigma>'' w'"
+assumes "frame \<sigma>  u \<sigma>'  u'"
+and     "frame \<sigma>' w \<sigma>'' w'"
 and     "\<Xi>, \<sigma>  \<turnstile> \<gamma> \<sim> \<gamma>' matches \<Gamma>  \<langle>r , w\<rangle>"
 and     "\<Xi>, \<sigma>' \<turnstile> v \<sim> v' : \<tau> \<langle>r', u'\<rangle>"
 and     "u \<inter> w = {}"
@@ -1447,13 +1447,13 @@ shows   "\<lbrakk> \<xi> , \<gamma>  \<turnstile> (\<sigma>, specialise \<tau>s 
          ; \<Xi>, K, \<Gamma> \<turnstile> e : \<tau>
          \<rbrakk> \<Longrightarrow> \<exists>r' w'. (\<Xi> , \<sigma>' \<turnstile> v \<sim> v' : instantiate \<tau>s \<tau> \<langle>r', w'\<rangle>)
                      \<and> r' \<subseteq> r
-                     \<and> upd.frame \<sigma> w \<sigma>' w'"
+                     \<and> frame \<sigma> w \<sigma>' w'"
 and     "\<lbrakk> \<xi> , \<gamma>  \<turnstile>* (\<sigma>, map (specialise \<tau>s) es) \<Down>! (\<sigma>', vs)
          ; \<xi>', \<gamma>' \<turnstile>*     map (specialise \<tau>s) es  \<Down>       vs'
          ; \<Xi>, K, \<Gamma> \<turnstile>* es : \<tau>s'
          \<rbrakk> \<Longrightarrow> \<exists>r' w'. (\<Xi>, \<sigma>' \<turnstile>* vs \<sim> vs' : map (instantiate \<tau>s) \<tau>s' \<langle>r', w'\<rangle>)
                      \<and> r' \<subseteq> r
-                     \<and> upd.frame \<sigma> w \<sigma>' w'"
+                     \<and> frame \<sigma> w \<sigma>' w'"
 using assms proof (induct "(\<sigma>, specialise \<tau>s e)"        "(\<sigma>', v )"
                       and "(\<sigma>, map (specialise \<tau>s) es)" "(\<sigma>', vs)"
                       arbitrary:  e  \<tau>s K \<tau>   \<Gamma> r w v  \<sigma>' \<sigma> \<gamma>' v'
@@ -1575,7 +1575,7 @@ next
     obtain r' w'
       where "\<Xi>, \<sigma>' \<turnstile> x'' \<sim> xa : instantiate \<tau>s t \<langle>r', w'\<rangle>"
         and r'_sub_r: "r' \<subseteq> r"
-        and frame_w_w': "upd.frame \<sigma> w \<sigma>' w'"
+        and frame_w_w': "frame \<sigma> w \<sigma>' w'"
       using u_sem_con.hyps(2) x_spec_is vsem_specialised_x typing_elims u_sem_con.prems
       by blast
     then have "\<Xi>, \<sigma>' \<turnstile> USum tag x'' (map ((\<lambda>(n, t, _). (n, type_repr t)) \<circ> (\<lambda>(c, t, b). (c, instantiate \<tau>s t, b))) ts)
@@ -1695,7 +1695,7 @@ next
   obtain r' w'
       where "\<Xi>, \<sigma>' \<turnstile> USum tagu v tsu' \<sim> VSum tag v' : instantiate \<tau>s (TSum tsty) \<langle>r', w'\<rangle>"
         and r'_sub_r: "r' \<subseteq> r"
-        and frame_w_w': "upd.frame \<sigma> w \<sigma>' w'"
+        and frame_w_w': "frame \<sigma> w \<sigma>' w'"
       using u_sem_esac.hyps(2) u_sem_esac.prems spec_simps utsem_elims typing_elims
       by blast
     then obtain instt
@@ -1782,7 +1782,7 @@ next
     then obtain w1' r1'
       where u_v_rel_sum_tag: "\<Xi>, \<sigma>a' \<turnstile> USum tag va rs \<sim> VSum tag vx : instantiate \<tau>s (TSum ts) \<langle>r1', w1'\<rangle>"
         and r_sub1: "r1' \<subseteq> r1"
-        and frame1: "upd.frame \<sigma>a w1 \<sigma>a' w1'"
+        and frame1: "frame \<sigma>a w1 \<sigma>a' w1'"
       using u_sem_case_nm.hyps(2) u_sem_case_nm.prems x_is v_sem_case_nm typing_x' matches1
       by blast
 
@@ -1854,10 +1854,10 @@ next
     then obtain r12' w12'
       where "\<Xi>, \<sigma>' \<turnstile> v \<sim> v' : instantiate \<tau>s \<tau> \<langle>r12', w12'\<rangle>"
         and r_sub12: "r12' \<subseteq> r1' \<union> r2"
-        and frame12: "upd.frame \<sigma>a' (w1' \<union> w2) \<sigma>' w12'"
+        and frame12: "frame \<sigma>a' (w1' \<union> w2) \<sigma>' w12'"
       using u_sem_case_nm.hyps(5) n_is vsem_specialise_n' typing_n' u_sem_case_nm.prems
       by blast
-    moreover have "upd.frame \<sigma>a w \<sigma>' w12'"
+    moreover have "frame \<sigma>a w \<sigma>' w12'"
       by (metis upd.frame_let w_as_un frame1 frame12 inf_sup_aci(5))
     ultimately show ?thesis
       using r_as_un r_sub1 by auto
@@ -1896,8 +1896,11 @@ next case (u_sem_if _ _ _ _ _ b)
     apply (frule(6) IH1, clarsimp)
     apply (erule u_v_primE)
     apply (clarsimp)
-    apply (frule(4) IH2 [ rotated 3
-                        , where e23 (* FIXME: unstable name *) = "if b then e2 else e3" for e2 and e3
+    \<comment>\<open>Instantiate the expression in the specialisation of @{thm IH2} with
+       @{term \<open>if b then e2 else e3\<close>} for some term @{term e2} and @{term e3}.
+       Instantiated using ''of'' instead of ''where'' since the naming is unstable.\<close>
+    apply (frule(4) IH2 [ of _ "if b then e2 else e3" for e2 and e3
+                        , rotated 3
                         , OF _ _ u_v_matches_frame ])
          apply (blast, simp)
        apply (cases b, simp, simp)+
@@ -2130,11 +2133,11 @@ next case u_sem_put
            apply (simp add: map_update)
           apply simp
          apply force
-        apply (clarsimp intro!: upd.list_helper[symmetric] simp: HELP2 map_update upd.frame_def)
+        apply (clarsimp intro!: upd.list_helper[symmetric] simp: HELP2 map_update frame_def)
        apply blast
       apply (force simp add: distinct_map map_update intro: distinct_list_update)
     apply auto[1]
-    apply (clarsimp simp add: upd.frame_def)
+    apply (clarsimp simp add: frame_def)
     done
 next case u_sem_put_ub
   note IH1  = this(2)
@@ -2176,7 +2179,7 @@ next case u_sem_put_ub
     apply (intro exI conjI u_v_struct)
        apply (simp add: map_update)
       apply (force simp add: distinct_map map_update intro: distinct_list_update)
-     apply (auto simp: upd.frame_def)[2]
+     apply (auto simp: frame_def)[2]
     done
 next case u_sem_split
   note IH1  = this(2)
@@ -2488,7 +2491,7 @@ next
  obtain r1' w1'
     where "\<Xi>, \<sigma>'' \<turnstile> USum tag' va rs \<sim> vxsum : TSum ts \<langle>r1', w1'\<rangle>"
       and r1'_sub_r1: "r1' \<subseteq> r1"
-      and frame1: "upd.frame \<sigma> w1 \<sigma>'' w1'"
+      and frame1: "frame \<sigma> w1 \<sigma>'' w1'"
    using mono_correspondence(1) u_sem_case_nm.hyps(1) u_sem_case_nm.prems matches1 vsem_x typing_x
    by blast
   then obtain vv t k

--- a/cogent/isa/UpdateSemantics.thy
+++ b/cogent/isa/UpdateSemantics.thy
@@ -176,7 +176,7 @@ locale update_sem =
   and     abs_typing_unique_repr   : "abs_typing av n \<tau>s s r w \<sigma> \<Longrightarrow> abs_typing av n' \<tau>s' s' r' w' \<sigma>
                                     \<Longrightarrow> type_repr (TCon n \<tau>s s) = type_repr (TCon n' \<tau>s' s')"
   and     abs_typing_repr : "abs_typing av n \<tau>s s r w \<sigma> \<Longrightarrow> abs_repr av = (n, map type_repr \<tau>s)"
-  and     abs_typing_frame: "frame \<sigma> u \<sigma>' u' \<Longrightarrow> abs_typing av n \<tau>s s r w \<sigma> \<Longrightarrow> f \<inter> u = {}
+  and     abs_typing_frame: "frame \<sigma> u \<sigma>' u' \<Longrightarrow> abs_typing av n \<tau>s s r w \<sigma> \<Longrightarrow> r \<inter> u = {}
                               \<Longrightarrow> w \<inter> u = {} \<Longrightarrow> abs_typing av n \<tau>s s r w \<sigma>'"
 
 context update_sem begin

--- a/cogent/isa/UpdateSemantics.thy
+++ b/cogent/isa/UpdateSemantics.thy
@@ -165,16 +165,19 @@ definition frame :: "('f, 'a, 'l) store \<Rightarrow> 'l set \<Rightarrow> ('f, 
 
 
 locale update_sem =
-  fixes abs_typing :: "'a \<Rightarrow> name \<Rightarrow> type list \<Rightarrow> sigil \<Rightarrow> 'l set \<Rightarrow> 'l set \<Rightarrow> bool"
+  fixes abs_typing :: "'a \<Rightarrow> name \<Rightarrow> type list \<Rightarrow> sigil \<Rightarrow> 'l set \<Rightarrow> 'l set \<Rightarrow> ('f, 'a, 'l) store \<Rightarrow> bool"
   and   abs_repr   :: "'a \<Rightarrow> name \<times> repr list"
-  assumes abs_typing_bang : "abs_typing av n \<tau>s s r w \<Longrightarrow> abs_typing av n (map bang \<tau>s) (bang_sigil s) (r \<union> w) {}"
-  and     abs_typing_noalias : "abs_typing av n \<tau>s s r w \<Longrightarrow> r \<inter> w = {}"
-  and     abs_typing_readonly : "sigil_perm s \<noteq> Some Writable \<Longrightarrow> abs_typing av n \<tau>s s r w \<Longrightarrow> w = {}"
-  and     abs_typing_escape   : "sigil_perm s \<noteq> Some ReadOnly \<Longrightarrow> [] \<turnstile>* \<tau>s :\<kappa> k \<Longrightarrow> E \<in> k \<Longrightarrow> abs_typing av n \<tau>s s r w \<Longrightarrow> r = {}"
-  and     abs_typing_valid : "abs_typing av n \<tau>s s r w \<Longrightarrow> p \<in> r \<union> w \<Longrightarrow> \<sigma> p \<noteq> None"
-  and     abs_typing_unique_repr   : "abs_typing av n \<tau>s s r w \<Longrightarrow> abs_typing av n' \<tau>s' s' r' w'
+  assumes abs_typing_bang : "abs_typing av n \<tau>s s r w \<sigma> \<Longrightarrow> abs_typing av n (map bang \<tau>s) (bang_sigil s) (r \<union> w) {} \<sigma>"
+  and     abs_typing_noalias : "abs_typing av n \<tau>s s r w \<sigma> \<Longrightarrow> r \<inter> w = {}"
+  and     abs_typing_readonly : "sigil_perm s \<noteq> Some Writable \<Longrightarrow> abs_typing av n \<tau>s s r w \<sigma> \<Longrightarrow> w = {}"
+  and     abs_typing_escape   : "sigil_perm s \<noteq> Some ReadOnly \<Longrightarrow> [] \<turnstile>* \<tau>s :\<kappa> k \<Longrightarrow> E \<in> k
+                                  \<Longrightarrow> abs_typing av n \<tau>s s r w \<sigma> \<Longrightarrow> r = {}"
+  and     abs_typing_valid : "abs_typing av n \<tau>s s r w \<sigma> \<Longrightarrow> p \<in> r \<union> w \<Longrightarrow> \<sigma> p \<noteq> None"
+  and     abs_typing_unique_repr   : "abs_typing av n \<tau>s s r w \<sigma> \<Longrightarrow> abs_typing av n' \<tau>s' s' r' w' \<sigma>
                                     \<Longrightarrow> type_repr (TCon n \<tau>s s) = type_repr (TCon n' \<tau>s' s')"
-  and     abs_typing_repr : "abs_typing av n \<tau>s s r w \<Longrightarrow> abs_repr av = (n, map type_repr \<tau>s)"
+  and     abs_typing_repr : "abs_typing av n \<tau>s s r w \<sigma> \<Longrightarrow> abs_repr av = (n, map type_repr \<tau>s)"
+  and     abs_typing_frame: "frame \<sigma> u \<sigma>' u' \<Longrightarrow> abs_typing av n \<tau>s s r w \<sigma> \<Longrightarrow> f \<inter> u = {}
+                              \<Longrightarrow> w \<inter> u = {} \<Longrightarrow> abs_typing av n \<tau>s s r w \<sigma>'"
 
 context update_sem begin
 
@@ -236,7 +239,7 @@ and uval_typing_record :: "('f \<Rightarrow> poly_type)
                   ; distinct (map fst ts)
                   \<rbrakk> \<Longrightarrow> \<Xi>, \<sigma> \<turnstile> URecord fs :u TRecord ts Unboxed \<langle>r, w\<rangle>"
 
-| u_t_abstract : "\<lbrakk> abs_typing a n ts Unboxed r w
+| u_t_abstract : "\<lbrakk> abs_typing a n ts Unboxed r w \<sigma>
                   ; [] \<turnstile>* ts wellformed
                   \<rbrakk> \<Longrightarrow> \<Xi>, \<sigma> \<turnstile> UAbstract a :u TCon n ts Unboxed \<langle>r, w\<rangle>"
 
@@ -266,13 +269,13 @@ and uval_typing_record :: "('f \<Rightarrow> poly_type)
                   \<rbrakk> \<Longrightarrow> \<Xi>, \<sigma> \<turnstile> UPtr l (RRecord (map (type_repr \<circ> fst \<circ> snd) ts)) :u TRecord ts (Boxed Writable ptrl) \<langle>r, insert l w\<rangle>"
 
 | u_t_p_abs_ro : "\<lbrakk> s = Boxed ReadOnly ptrl
-                  ; abs_typing a n ts s r {}
+                  ; abs_typing a n ts s r {} \<sigma>
                   ; [] \<turnstile>* ts wellformed
                   ; \<sigma> l = Some (UAbstract a)
                   \<rbrakk> \<Longrightarrow> \<Xi>, \<sigma> \<turnstile> UPtr l (RCon n (map type_repr ts)) :u TCon n ts s \<langle>insert l r, {}\<rangle>"
 
 | u_t_p_abs_w  : "\<lbrakk> s = Boxed Writable ptrl
-                  ; abs_typing a n ts s r w
+                  ; abs_typing a n ts s r w \<sigma>
                   ; [] \<turnstile>* ts wellformed
                   ; \<sigma> l = Some (UAbstract a)
                   ; l \<notin> (w \<union> r)
@@ -1152,13 +1155,17 @@ using assms  proof(induct  rule:uval_typing_uval_typing_record.inducts)
 next case u_t_product  then show ?case by (fastforce intro!: uval_typing_uval_typing_record.intros)
 next case u_t_sum      then show ?case by (fastforce intro!: uval_typing_uval_typing_record.intros)
 next case u_t_struct   then show ?case by (fastforce intro!: uval_typing_uval_typing_record.intros)
-next case u_t_abstract then show ?case by (simp add: uval_typing_uval_typing_record.u_t_abstract)
+next case u_t_abstract then show ?case by (simp add: uval_typing_uval_typing_record.u_t_abstract abs_typing_frame)
 next case u_t_function then show ?case by (simp add: uval_typing_uval_typing_record.u_t_function)
 next case u_t_unit     then show ?case by (simp add: uval_typing_uval_typing_record.u_t_unit)
 next case u_t_r_empty  then show ?case by (simp add: uval_typing_uval_typing_record.u_t_r_empty)
 next case u_t_r_cons1  then show ?case by (force simp: frame_def
                                                  intro!: uval_typing_uval_typing_record.u_t_r_cons1)
 next case u_t_r_cons2  then show ?case by (simp add: uval_typing_uval_typing_record.u_t_r_cons2)
+next case u_t_p_abs_ro then show ?case by (auto simp: frame_def abs_typing_frame
+                                                intro!: uval_typing_uval_typing_record.u_t_p_abs_ro)
+next case u_t_p_abs_w then show ?case by (auto simp: frame_def abs_typing_frame
+                                                intro!: uval_typing_uval_typing_record.u_t_p_abs_w)
 qed (fastforce simp:   frame_def
                intro!: uval_typing_uval_typing_record.intros)+
 

--- a/cogent/src/Cogent/Isabelle/AllRefine.hs
+++ b/cogent/src/Cogent/Isabelle/AllRefine.hs
@@ -110,9 +110,9 @@ initFinalLocale thy output = TheoryString $ unlines
   , "locale " ++ thy ++ "_cogent_shallow ="
   , "  \"" ++ output ++ "\" + correspondence +"
   , "  constrains val_abs_typing :: \"'b \\<Rightarrow> name \\<Rightarrow> type list \\<Rightarrow> bool\""
-  , "         and upd_abs_typing :: \"abstyp \\<Rightarrow> name \\<Rightarrow> type list \\<Rightarrow> sigil \\<Rightarrow> ptrtyp set \\<Rightarrow> ptrtyp set \\<Rightarrow> bool\""
+  , "         and upd_abs_typing :: \"abstyp \\<Rightarrow> name \\<Rightarrow> type list \\<Rightarrow> sigil \\<Rightarrow> ptrtyp set \\<Rightarrow> ptrtyp set \\<Rightarrow> (funtyp, abstyp, ptrtyp) store \\<Rightarrow> bool\""
   , "         and abs_repr       :: \"abstyp \\<Rightarrow> name \\<times> repr list\""
-  , "         and abs_upd_val    :: \"abstyp \\<Rightarrow> 'b \\<Rightarrow> char list \\<Rightarrow> Cogent.type list \\<Rightarrow> sigil \\<Rightarrow> " ++ wordSize ++ " word set \\<Rightarrow> " ++ wordSize ++ " word set \\<Rightarrow> bool\""
+  , "         and abs_upd_val    :: \"abstyp \\<Rightarrow> 'b \\<Rightarrow> char list \\<Rightarrow> Cogent.type list \\<Rightarrow> sigil \\<Rightarrow> " ++ wordSize ++ " word set \\<Rightarrow> " ++ wordSize ++ " word set \\<Rightarrow> (char list, abstyp, " ++ wordSize ++ " word) store \\<Rightarrow> bool\""
   ]
  where wordSize = show $ primIntSizeBits machineWordType
 


### PR DESCRIPTION
This fixes the abstract typing relation in the update semantics and the value relation between the update and value semantics for abstract types. Both of these relations were broken due to not taking the Cogent heap as an argument.

Before this fix, one could show that all pointers in an abstract value are valid, i.e. point to something, for all Cogent heaps, which is clearly incorrect.

With these fixes, an additional constraint on abstract types is required, i.e. their values satisfy the frame constraint, in order to prove the uval_typing_frame and upd_val_rel_frame theorems. This addition should not adversely affect Cogent since this constraint is alluded to in "Type Systems for System Types", chapter 4,  subsection "Abstract Values", page 88, (https://www.unsworks.unsw.edu.au/primo-explore/fulldisplay?docid=unsworks_61747&vid=UNSWORKS&search_scope=unsworks_search_scope&tab=default_tab&lang=en_US&context=L).