### PR TITLE
update ansi-wl-pprint dependencies

### DIFF
--- a/cogent/cogent.cabal
+++ b/cogent/cogent.cabal
@@ -176,7 +176,7 @@ library
               , Version_cogent
 
   build-depends:
-                ansi-wl-pprint >= 0.6
+                ansi-wl-pprint >= 0.6 && < 1
               , base >= 4.10 && < 4.17
               , binary
               , bytestring >= 0.10
@@ -255,7 +255,7 @@ Executable cogent
 
   build-depends:
                 cogent
-              , ansi-wl-pprint >= 0.6
+              , ansi-wl-pprint >= 0.6 && < 1
               , atomic-write >= 0.2.0.4
               , base >= 4.10 && < 4.17
               , binary
@@ -334,4 +334,4 @@ test-suite test-quickcheck
               , QuickCheck >= 2.11.3
               , transformers
               , mtl >= 2.2.1
-              , ansi-wl-pprint >= 0.6
+              , ansi-wl-pprint >= 0.6 && < 1

--- a/isa-parser/isa-parser.cabal
+++ b/isa-parser/isa-parser.cabal
@@ -32,9 +32,9 @@ library
     DeriveDataTypeable, 
     QuasiQuotes
 
-  build-depends:       
+  build-depends:
     haskell-exp-parser >= 0.1.1,
-    ansi-wl-pprint >= 0.6,
+    ansi-wl-pprint >= 0.6 && < 1,
     base >= 4.7,
     mtl >= 2.2.1,
     parsec >= 3.1,


### PR DESCRIPTION
They changed their interface and broke the build. My simple fix is to restrict the version to before 1.0